### PR TITLE
Replace invalid script paths with valid ones

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,8 @@
 <html>
 <head>
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <script src="http://cdn.clappr.io/latest/jquery.js"></script>
-  <script src="http://cdn.clappr.io/latest/underscore.js"></script>
+  <script src="http://cdn.clappr.io/j/vendor/jquery.min.js"></script>
+  <script src="http://cdn.clappr.io/j/vendor/underscore-min.js"></script>
   <script src="http://cdn.clappr.io/latest/clappr.min.js"></script>
   <script src="http://cdn.clappr.io/bemtv/latest/p2phlsstats.min.js"></script>
   <script src="p2phls.js"></script>

--- a/index.html
+++ b/index.html
@@ -2,8 +2,8 @@
 <html>
 <head>
   <meta http-equiv="content-type" content="text/html; charset=utf-8" />
-  <script src="http://cdn.clappr.io/j/vendor/jquery.min.js"></script>
-  <script src="http://cdn.clappr.io/j/vendor/underscore-min.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
+  <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.7.0/underscore-min.js"></script>
   <script src="http://cdn.clappr.io/latest/clappr.min.js"></script>
   <script src="http://cdn.clappr.io/bemtv/latest/p2phlsstats.min.js"></script>
   <script src="p2phls.js"></script>


### PR DESCRIPTION
When following the tutorial described here https://github.com/bemtv/bemtv/wiki/tutorial it does n't work as expected when opening http://localhost:3000 due to invaid script path. This patch resolves this.
